### PR TITLE
Fix compatibility break for CaseFileEvents up to version 1.1.8

### DIFF
--- a/case-engine/src/main/java/org/cafienne/akka/actor/serialization/EventSerializer.java
+++ b/case-engine/src/main/java/org/cafienne/akka/actor/serialization/EventSerializer.java
@@ -73,6 +73,7 @@ public class EventSerializer extends CafienneSerializer {
         addManifestWrapper(CaseFileItemReplaced.class, CaseFileItemReplaced::new);
         addManifestWrapper(CaseFileItemDeleted.class, CaseFileItemDeleted::new);
         addManifestWrapper(CaseFileItemChildRemoved.class, CaseFileItemChildRemoved::new);
+        // Note: CaseFileEvent event cannot be deleted, since sub class events above were introduced only in 1.1.9
         addManifestWrapper(CaseFileEvent.class, CaseFileEvent::new);
         addManifestWrapper(BusinessIdentifierSet.class, BusinessIdentifierSet::new);
         addManifestWrapper(BusinessIdentifierCleared.class, BusinessIdentifierCleared::new);

--- a/case-engine/src/main/java/org/cafienne/cmmn/akka/event/file/CaseFileEvent.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/akka/event/file/CaseFileEvent.java
@@ -28,31 +28,25 @@ import java.io.IOException;
 public class CaseFileEvent extends CaseEvent implements StandardEvent<CaseFileItemTransition> {
     protected final static Logger logger = LoggerFactory.getLogger(CaseFileEvent.class);
 
-    private final String name;
     private final CaseFileItemTransition transition;
     private final Value<?> value;
     protected final Path path;
     private final State state;
-    private final int index;
 
     public CaseFileEvent(CaseFileItemCollection<?> item, State newState, CaseFileItemTransition transition, Value<?> newValue) {
         super(item.getCaseInstance());
-        this.name = item.getName();
         this.transition = transition;
         this.value = newValue;
         this.path = item.getPath();
         this.state = newState;
-        this.index = item.getIndex();
     }
 
     public CaseFileEvent(ValueMap json) {
         super(json);
-        this.name = json.raw(Fields.name);
         this.transition = json.getEnum(Fields.transition, CaseFileItemTransition.class);
         this.value = json.get(Fields.value.toString());
         this.path = readPath(json, Fields.path);
         this.state = readEnum(json, Fields.state, State.class);
-        this.index = json.rawInt(Fields.index.toString());
     }
 
     @Override
@@ -87,16 +81,7 @@ public class CaseFileEvent extends CaseEvent implements StandardEvent<CaseFileIt
      * @return
      */
     public int getIndex() {
-        return index;
-    }
-
-    /**
-     * Returns the name of the case file item
-     *
-     * @return
-     */
-    public String getCaseFileItemName() {
-        return name;
+        return path.getIndex();
     }
 
     /**
@@ -151,8 +136,6 @@ public class CaseFileEvent extends CaseEvent implements StandardEvent<CaseFileIt
         writeField(generator, Fields.transition, transition);
         writeField(generator, Fields.path, path);
         writeField(generator, Fields.value, value);
-        writeField(generator, Fields.name, name);
         writeField(generator, Fields.state, state);
-        generator.writeNumberField(Fields.index.toString(), index);
     }
 }

--- a/case-engine/src/main/java/org/cafienne/cmmn/test/assertions/file/CaseFileItemAssertion.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/test/assertions/file/CaseFileItemAssertion.java
@@ -145,7 +145,7 @@ public class CaseFileItemAssertion extends ModelTestCommandAssertion {
     }
 
     private String getName() {
-        return getEventValue(e -> e.getCaseFileItemName(), path.toString());
+        return getEventValue(e -> e.getPath().getName(), path.toString());
     }
 
     private <T> T getEventValue(EventValuePicker<T> picker, T defaultValue) {


### PR DESCRIPTION
Specific CaseFile events (CaseFileItemCreated, etc) were introduced in version 1.1.9, so older versions do not generate them.
Hence CaseFileMerger has to check for the older event format as well.
This is fixed now by only looking at the event's transition.
Note, also CaseFileEvent json data is reduced, since info was unnecessarily duplicated  thanks to new Path implementation