### PR TITLE
Fix reading default value for newly introduced event field

### DIFF
--- a/case-engine/src/main/java/org/cafienne/akka/actor/serialization/CafienneSerializable.java
+++ b/case-engine/src/main/java/org/cafienne/akka/actor/serialization/CafienneSerializable.java
@@ -139,6 +139,14 @@ public interface CafienneSerializable {
         return json.raw(fieldName);
     }
 
+    default <T extends Object> T readField(ValueMap json, Fields fieldName, T defaultValue) {
+        if (json.has(fieldName)) {
+            return readField(json, fieldName);
+        } else {
+            return defaultValue;
+        }
+    }
+
     default <T extends Enum<?>> T readEnum(ValueMap json, Fields fieldName, Class<T> enumClass) {
         return json.getEnum(fieldName, enumClass);
     }

--- a/case-engine/src/main/java/org/cafienne/cmmn/akka/event/plan/PlanItemCreated.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/akka/event/plan/PlanItemCreated.java
@@ -50,7 +50,7 @@ public class PlanItemCreated extends PlanItemEvent {
         this.createdOn = readInstant(json, Fields.createdOn);
         this.createdBy = readField(json, Fields.createdBy);
         this.planItemName = readField(json, Fields.name);
-        this.definitionId = readField(json, Fields.definitionId);
+        this.definitionId = readField(json, Fields.definitionId, "");
         this.stageId = readField(json, Fields.stageId);
     }
 


### PR DESCRIPTION
Updating database for new non-null column should not try to set events with NULL value if the newly added event field is not filled.
This fix sets the default event field value to an empty string.