### PR TITLE
Support for conditional process task output mappings

### DIFF
--- a/case-engine/src/main/java/org/cafienne/cmmn/definition/ParameterMappingDefinition.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/definition/ParameterMappingDefinition.java
@@ -157,6 +157,14 @@ public class ParameterMappingDefinition extends CMMNElementDefinition {
     }
 
     /**
+     * Returns true if the mapping has a transformation element with an actual expression in it.
+     * @return
+     */
+    public boolean hasTransformation() {
+        return transformation != null && !transformation.getBody().isBlank();
+    }
+
+    /**
      * Indicates whether this mapping is to be executed before or after the Task is executed. This is determined automagically based on the parameter references. They must either both refer to input
      * parameters or to output parameters. Also, in case the sourceRef and targetRef refer to input parameters this means the mapping is to be executed before the task is executed. If they refer to
      * output parameters, the mapping is executed after the task has been completed.
@@ -191,7 +199,7 @@ public class ParameterMappingDefinition extends CMMNElementDefinition {
      */
     public Value<?> transformOutput(Task<?> task, Value<?> value) {
         Value<?> targetValue = value;
-        if (transformation != null && !transformation.getBody().isEmpty()) {
+        if (this.hasTransformation()) {
             targetValue = transformation.getEvaluator().evaluateOutputParameterTransformation(task.getCaseInstance(), value, source, target, task);
         }
         return targetValue;

--- a/case-engine/src/main/java/org/cafienne/processtask/definition/SubProcessDefinition.java
+++ b/case-engine/src/main/java/org/cafienne/processtask/definition/SubProcessDefinition.java
@@ -60,6 +60,8 @@ import org.w3c.dom.Element;
 public abstract class SubProcessDefinition extends CMMNElementDefinition {
 
     private final Collection<SubProcessMapping> mappings = new ArrayList();
+    private final Collection<SubProcessMapping> successMappings = new ArrayList();
+    private final Collection<SubProcessMapping> failureMappings = new ArrayList();
     private final boolean isAsync;
     /**
      * Default exception parameter, can be used to store Throwables.
@@ -71,6 +73,10 @@ public abstract class SubProcessDefinition extends CMMNElementDefinition {
         super(element, processDefinition, parentElement);
         isAsync = Boolean.parseBoolean(parseAttribute("async", false, "true")); // By default, processes are executed asynchronously
         parse("parameterMapping", SubProcessMapping.class, mappings);
+        successMappings.addAll(mappings);
+        failureMappings.addAll(mappings);
+        parseGrandChildren("success", "parameterMapping", SubProcessMapping.class, successMappings);
+        parseGrandChildren("failure", "parameterMapping", SubProcessMapping.class, failureMappings);
     }
 
     /**
@@ -83,11 +89,22 @@ public abstract class SubProcessDefinition extends CMMNElementDefinition {
 
     /**
      * Gets the parameter mappings for the sub-process
+     * that must be executed when the subprocess succesfully completes
      *
      * @return parameter mapping
      */
-    public Collection<SubProcessMapping> getParameterMappings() {
-        return mappings;
+    public Collection<SubProcessMapping> getSuccessMappings() {
+        return successMappings;
+    }
+
+    /**
+     * Gets the parameter mappings for the sub-process
+     * that must be executed upon a failing subprocess
+     *
+     * @return parameter mapping
+     */
+    public Collection<SubProcessMapping> getFailureMappings() {
+        return failureMappings;
     }
 
     /**


### PR DESCRIPTION
ProcessTask implementations can now distinguish between mappings to be done upon failure and mappings to be done upon success.
Task output mapping is only done if there is an actual raw output parameter.

Fixes #178