### PR TITLE
Avoid running task output validation during recovery

### DIFF
--- a/case-engine/src/main/java/org/cafienne/actormodel/ModelActor.java
+++ b/case-engine/src/main/java/org/cafienne/actormodel/ModelActor.java
@@ -20,8 +20,6 @@ import org.cafienne.actormodel.event.TransactionEvent;
 import org.cafienne.actormodel.handler.*;
 import org.cafienne.actormodel.identity.TenantUser;
 import org.cafienne.cmmn.actorapi.command.CaseCommand;
-import org.cafienne.cmmn.actorapi.event.file.CaseFileEvent;
-import org.cafienne.cmmn.actorapi.event.plan.PlanItemEvent;
 import org.cafienne.cmmn.instance.debug.DebugJsonAppender;
 import org.cafienne.cmmn.instance.debug.DebugStringAppender;
 import org.cafienne.infrastructure.Cafienne;
@@ -491,16 +489,7 @@ public abstract class ModelActor<C extends ModelCommand, E extends ModelEvent> e
     public <T> void persistEventsAndThenReply(List<T> events, ModelResponse response) {
         if (getLogger().isDebugEnabled() || EngineDeveloperConsole.enabled()) {
             StringBuilder msg = new StringBuilder("\n------------------------ PERSISTING " + events.size() + " EVENTS IN " + this);
-            events.forEach(e -> {
-                msg.append("\n\t");
-                if (e instanceof PlanItemEvent) {
-                    msg.append(e.toString());
-                } else if (e instanceof CaseFileEvent) {
-                    msg.append(e.getClass().getSimpleName() + "." + ((CaseFileEvent) e).getTransition() + "()[" + ((CaseFileEvent) e).getPath() + "]");
-                } else {
-                    msg.append(e.getClass().getSimpleName() + ", ");
-                }
-            });
+            events.forEach(e -> msg.append("\n\t" + e));
             getLogger().debug(msg + "\n");
             EngineDeveloperConsole.debugIndentedConsoleLogging(msg + "\n");
         }

--- a/case-engine/src/main/java/org/cafienne/cmmn/actorapi/event/plan/task/TaskInputFilled.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/actorapi/event/plan/task/TaskInputFilled.java
@@ -17,7 +17,7 @@ import org.cafienne.json.ValueMap;
 import java.io.IOException;
 
 @Manifest
-public class TaskInputFilled extends TaskEvent {
+public class TaskInputFilled extends TaskEvent<Task<?>> {
     private final ValueMap taskParameters;
     private final ValueMap mappedInputParameters;
 

--- a/case-engine/src/main/java/org/cafienne/cmmn/actorapi/event/plan/task/TaskOutputFilled.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/actorapi/event/plan/task/TaskOutputFilled.java
@@ -17,7 +17,7 @@ import org.cafienne.json.ValueMap;
 import java.io.IOException;
 
 @Manifest
-public class TaskOutputFilled extends TaskEvent {
+public class TaskOutputFilled extends TaskEvent<Task<?>> {
     private final ValueMap parameters;
     private final ValueMap rawOutputParameters;
 

--- a/case-engine/src/main/java/org/cafienne/cmmn/definition/casefile/definitiontype/JSONType.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/definition/casefile/definitiontype/JSONType.java
@@ -48,7 +48,7 @@ public class JSONType extends DefinitionType {
         PropertyDefinition.PropertyType type = propertyDefinition.getPropertyType();
         try {
             if (!propertyValue.matches(type)) {
-                throw new CaseFileError("Property '" + propertyDefinition.getName() + "' has wrong type, expecting " + type);
+                throw new CaseFileError("Property '" + propertyDefinition.getName() + "' has wrong type, expecting " + type + ", found a " + propertyValue.getClass().getSimpleName());
             }
         } catch (IllegalArgumentException improperType) {
             throw new CaseFileError("Property '" + propertyDefinition.getName() + "' has wrong type, expecting " + type + ", found exception " + improperType.getMessage());

--- a/case-engine/src/main/java/org/cafienne/cmmn/instance/task/humantask/HumanTask.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/instance/task/humantask/HumanTask.java
@@ -57,9 +57,9 @@ public class HumanTask extends Task<HumanTaskDefinition> {
         if (validator != null) {
             ValidationResponse response = validator.validate(potentialRawOutput);
             if (!response.isValid()) {
-                addDebugInfo(() -> "Ouput validation for task " + getName() + "[" + getId() + "] failed with ", response.getContent());
+                addDebugInfo(() -> "Output validation for task " + getName() + "[" + getId() + "] failed with ", response.getContent());
             } else {
-                addDebugInfo(() -> "Ouput validation for task " + getName() + "[" + getId() + "] succeeded with ", response.getContent());
+                addDebugInfo(() -> "Output validation for task " + getName() + "[" + getId() + "] succeeded with ", response.getContent());
             }
             return response;
         } else {


### PR DESCRIPTION
- Event recovery should not run behavior.
- Also running task output validation at an earlier stage, before generating the event.

Both avoid running into issues during recovery.
Fixes #253