### PR TITLE
repository list fix

### DIFF
--- a/case-service/src/main/scala/org/cafienne/service/api/repository/RepositoryRoute.scala
+++ b/case-service/src/main/scala/org/cafienne/service/api/repository/RepositoryRoute.scala
@@ -98,7 +98,8 @@ class RepositoryRoute()(override implicit val userCache: IdentityProvider, overr
       userWithTenant { (platformUser, tenant) => {
         import scala.jdk.CollectionConverters._
 
-        val models = new ValueMap // Resulting JSON structure: { 'models': [ {}, {}, {} ] }
+        val models = new ValueMap()
+        models.withArray("models") // Resulting JSON structure: { 'models': [ {}, {}, {} ] }
         for (file <- Cafienne.config.repository.DefinitionProvider.list(platformUser, tenant).asScala) {
           var description = "Description"
           try {


### PR DESCRIPTION
When the repository is empty, the response should be an object with models: [] instead of {}
