### PR TITLE
Fix upsert casefile

### DIFF
--- a/case-engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFile.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFile.java
@@ -7,7 +7,6 @@
  */
 package org.cafienne.cmmn.instance.casefile;
 
-import org.cafienne.actormodel.exception.InvalidCommandException;
 import org.cafienne.cmmn.definition.casefile.CaseFileDefinition;
 import org.cafienne.cmmn.definition.casefile.CaseFileError;
 import org.cafienne.cmmn.instance.Case;
@@ -37,12 +36,12 @@ public class CaseFile extends CaseFileItemCollection<CaseFileDefinition> {
         if (newContent.isMap()) {
             newContent.asMap().fieldNames().forEachRemaining(name -> {
                 if (getItem(name) == null) {
-                    throw new InvalidCommandException("A case file item with name '" + name + "' is not defined");
+                    throw new CaseFileError("A case file item with name '" + name + "' is not defined");
                 }
             });
             return newContent.asMap();
         }
-        throw new InvalidCommandException("Operations on entire case file need a JSON object structure");
+        throw new CaseFileError("Operations on entire case file need a JSON object structure");
     }
 
     @Override

--- a/case-engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItem.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItem.java
@@ -10,6 +10,7 @@ package org.cafienne.cmmn.instance.casefile;
 import org.cafienne.actormodel.exception.InvalidCommandException;
 import org.cafienne.cmmn.actorapi.event.file.*;
 import org.cafienne.cmmn.definition.CMMNElementDefinition;
+import org.cafienne.cmmn.definition.casefile.CaseFileError;
 import org.cafienne.cmmn.definition.casefile.CaseFileItemDefinition;
 import org.cafienne.cmmn.definition.casefile.PropertyDefinition;
 import org.cafienne.cmmn.instance.Case;
@@ -533,7 +534,7 @@ public class CaseFileItem extends CaseFileItemCollection<CaseFileItemDefinition>
     public void validateTransition(CaseFileItemTransition intendedTransition, Value<?> content) {
         // Validate current state against transition
         if (!allowTransition(intendedTransition)) {
-            throw new InvalidCommandException(intendedTransition + "CaseFileItem[" + getPath() + "] cannot be done because item is in state " + getState());
+            throw new CaseFileError(intendedTransition + "CaseFileItem[" + getPath() + "] cannot be done because item is in state " + getState());
         }
 
         // Validate type of new content
@@ -543,7 +544,8 @@ public class CaseFileItem extends CaseFileItemCollection<CaseFileItemDefinition>
     protected boolean allowTransition(CaseFileItemTransition intendedTransition) {
         switch (getState()) {
             case Null:
-                return intendedTransition == CaseFileItemTransition.Create;
+                // Also support upserting a case file item; note: we explicitly do NOT check whether the parent CFI is in state Available. Not sure if that is required...
+                return intendedTransition == CaseFileItemTransition.Create || intendedTransition == CaseFileItemTransition.Update || intendedTransition == CaseFileItemTransition.Replace;
             case Available:
                 return intendedTransition == CaseFileItemTransition.Update || intendedTransition == CaseFileItemTransition.Replace || intendedTransition == CaseFileItemTransition.Delete;
             default: {

--- a/case-engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItem.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItem.java
@@ -532,6 +532,11 @@ public class CaseFileItem extends CaseFileItemCollection<CaseFileItemDefinition>
 
     @Override
     public void validateTransition(CaseFileItemTransition intendedTransition, Value<?> content) {
+        if (parent != null) {
+            if (parent.getState() == State.Discarded || parent.getState() == State.Null) {
+                throw new CaseFileError(intendedTransition + "CaseFileItem[" + getPath() + "] cannot be done because the parent is in state " + parent.getState());
+            }
+        }
         // Validate current state against transition
         if (!allowTransition(intendedTransition)) {
             throw new CaseFileError(intendedTransition + "CaseFileItem[" + getPath() + "] cannot be done because item is in state " + getState());

--- a/case-engine/src/test/java/org/cafienne/cmmn/test/casefile/AddRemoveChildTest.java
+++ b/case-engine/src/test/java/org/cafienne/cmmn/test/casefile/AddRemoveChildTest.java
@@ -101,7 +101,7 @@ public class AddRemoveChildTest {
         childItem.putRaw("world", "child-string");
         CreateCaseFileItem createChild2 = new CreateCaseFileItem(testUser, caseInstanceId, childItem.cloneValueNode(), testChildPath);
         // In case the parent does not have state == Active, CaseFileItemChildAdded should not be triggered
-        testCase.addStep(createChild2, caseFile -> caseFile.assertCaseFileItem(testPath).assertState(State.Null));
+        testCase.assertStepFails(createChild2);
 
         testCase.runTest();
     }

--- a/case-engine/src/test/java/org/cafienne/cmmn/test/casefile/NewCaseFileTest.java
+++ b/case-engine/src/test/java/org/cafienne/cmmn/test/casefile/NewCaseFileTest.java
@@ -22,29 +22,6 @@ public class NewCaseFileTest {
     private final TenantUser user = TestScript.getTestUser("Anonymous");
 
     private final Path rootPath = new Path("RootCaseFileItem");
-    private final Path grandChildArrayPath = new Path("RootCaseFileItem/ChildItem/GrandChildArray");
-
-    @Test
-    public void testCreateGrandChildWithoutFirstCreatingParents() {
-
-        String caseInstanceId = new Guid().toString();
-        TestScript testCase = new TestScript(caseName);
-
-        StartCase startCase = new StartCase(user, caseInstanceId, definitions, new ValueMap(), null);
-
-        testCase.addStep(startCase, casePlan -> {
-            casePlan.print();
-        });
-
-        ValueList grandChildren = new ValueList(createGrandChildItem(), createGrandChildItem());
-        testCase.addStep(new CreateCaseFileItem(user, caseInstanceId, grandChildren, grandChildArrayPath), result -> {
-            result.print();
-            result.getEvents().printEventList();
-            result.getEvents().assertSize(3);
-        });
-
-        testCase.runTest();
-    }
 
     @Test
     public void testCreateAndModifyFullCaseFile() {

--- a/case-engine/src/test/java/org/cafienne/cmmn/test/expression/VariousSpelExpressions.java
+++ b/case-engine/src/test/java/org/cafienne/cmmn/test/expression/VariousSpelExpressions.java
@@ -72,6 +72,10 @@ public class VariousSpelExpressions {
             testCase.getEventListener().awaitPlanItemState("HumanTask", State.Active);
         });
 
+        testCase.addStep(new CreateCaseFileItem(user, caseInstanceId, new ValueMap(), new Path("SpecialOutput")), result -> {
+            result.assertPlanItems("HumanTask").assertSize(1).assertStates(State.Active);
+            result.assertPlanItems("Milestone").assertSize(1).assertStates(State.Available);
+        });
         testCase.addStep(new CreateCaseFileItem(user, caseInstanceId, new LongValue(1), new Path("SpecialOutput/Multi")), result -> {
             result.assertPlanItems("HumanTask").assertSize(1).assertStates(State.Active);
             result.assertPlanItems("Milestone").assertSize(1).assertStates(State.Available);


### PR DESCRIPTION
This new behavior gives a little more friendly case file API.
Note: in addition it is less friendly on creating children to non-existing parents: this has faulty behavior in the downstream processing, and is now blocked at the entry point.