### PR TITLE
Enable to always show docker logs of engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ jobs:
       - run:
           name: Docker logs of engine
           command: docker logs cafienne
+          when: always
       - run:
           name: Stop the containers
           command: docker rm -f cafienne sql-server cafienne-test-token-service
@@ -294,6 +295,7 @@ jobs:
       - run:
           name: Docker logs of engine
           command: docker logs cafienne
+          when: always
       - run:
           name: Stop the containers
           command: |
@@ -503,6 +505,7 @@ jobs:
       - run:
           name: Docker logs of engine
           command: docker logs cafienne
+          when: always
       - run:
           name: Stop the containers
           command: docker rm -f cafienne sql-server cafienne-test-token-service


### PR DESCRIPTION
Earlier removal of statement "when: on_fail" no longer showed the docker logs upon failures. Now reverted that change and made it "when: always"