### PR TITLE
PlanItem completion for HumanTask goes through extension

### DIFF
--- a/case-engine/src/main/java/org/cafienne/cmmn/instance/task/humantask/HumanTask.java
+++ b/case-engine/src/main/java/org/cafienne/cmmn/instance/task/humantask/HumanTask.java
@@ -47,6 +47,15 @@ public class HumanTask extends Task<HumanTaskDefinition> {
     }
 
     @Override
+    public boolean makeTransition(Transition transition) {
+        if (transition == Transition.Complete && getState() == State.Active) {
+            return workflow.complete(new ValueMap());
+        } else {
+            return super.makeTransition(transition);
+        }
+    }
+
+    @Override
     public ValidationResponse validateOutput(ValueMap potentialRawOutput) {
         // Create an instance of the output validator if we have one
         TaskOutputValidatorDefinition outputValidator = getDefinition().getTaskOutputValidator();

--- a/case-engine/src/main/java/org/cafienne/humantask/instance/WorkflowTask.java
+++ b/case-engine/src/main/java/org/cafienne/humantask/instance/WorkflowTask.java
@@ -185,7 +185,7 @@ public class WorkflowTask extends CMMNElement<WorkflowTaskDefinition> {
         addEvent(new HumanTaskOwnerChanged(task, newOwner));
     }
 
-    public void complete(ValueMap taskOutput) {
+    public boolean complete(ValueMap taskOutput) {
         // TTDL
         // First validate task output. Note: this may result in "CommandException", instead of "InvalidCommandException". For that reason this cannot be done right now in validate method.
         ValidationResponse validate = task.validateOutput(taskOutput);
@@ -199,7 +199,7 @@ public class WorkflowTask extends CMMNElement<WorkflowTaskDefinition> {
 
         addEvent(new HumanTaskCompleted(task, taskOutput));
         // This will generate PlanItemTransitioned and CaseFileItem events
-        task.goComplete(taskOutput);
+        return task.goComplete(taskOutput);
     }
 
     public void setDueDate(Instant newDueDate) {

--- a/case-service/src/main/scala/org/cafienne/service/db/materializer/cases/plan/CasePlanProjection.scala
+++ b/case-service/src/main/scala/org/cafienne/service/db/materializer/cases/plan/CasePlanProjection.scala
@@ -112,10 +112,7 @@ class CasePlanProjection(persistence: RecordsPersistence)(implicit val execution
             case evt: HumanTaskActivated => TaskMerger(evt, copy)
             case evt: HumanTaskCompleted => TaskMerger(evt, copy)
             case evt: HumanTaskTerminated => TaskMerger(evt, copy)
-            case other => {
-              logger.error("We missed out on HumanTaskTransition event of type " + other.getClass.getName)
-              copy
-            }
+            case other => copy // No need to do any further updates to the task record
           }
         }))
         case evt: HumanTaskMigrated => fetchTask(event.taskId).map(t => t.map(task => TaskMerger(evt, task)))


### PR DESCRIPTION
When the "complete" transition is invoked on a plan item, and that plan item is of type HumanTask, then it no longer bypasses the HumanTask.complete logic, but invokes it with empty output instead.
Future suggestions:
- extend makeTransition route with a json structure so that it can be used to complete a task with a non-empty output as well
- also implement the same logic for CaseTask and ProcessTask ... Or avoid that they can be completed from the REST api???