### PR TITLE
Check entry criteria presence based on definition instead of instance

### DIFF
--- a/src/main/java/org/cafienne/cmmn/instance/PlanItemEntry.java
+++ b/src/main/java/org/cafienne/cmmn/instance/PlanItemEntry.java
@@ -47,7 +47,7 @@ public class PlanItemEntry extends CriteriaListener<EntryCriterionDefinition, En
     }
 
     public boolean isEmpty() {
-        return criteria.isEmpty();
+        return definitions.isEmpty();
     }
 
     private Criterion<?> earlyBird = null;
@@ -77,7 +77,7 @@ public class PlanItemEntry extends CriteriaListener<EntryCriterionDefinition, En
             //  initiate that with the entry transition
             item.addDebugInfo(() -> criterion + " is satisfied and will repeat " + item);
             release();
-            item.repeat();
+            item.repeat("an entry criterion was satisfied");
         }
     }
 

--- a/src/main/java/org/cafienne/cmmn/instance/StateMachine.java
+++ b/src/main/java/org/cafienne/cmmn/instance/StateMachine.java
@@ -7,7 +7,6 @@
  */
 package org.cafienne.cmmn.instance;
 
-import org.cafienne.actormodel.exception.CommandException;
 import org.cafienne.cmmn.actorapi.event.plan.PlanItemTransitioned;
 
 import java.util.HashMap;
@@ -194,13 +193,13 @@ class StateMachine {
         TaskStage.setAction(State.Completed, (PlanItem<?> p, Transition t) -> {
             p.completeInstance();
             if (p.getEntryCriteria().isEmpty()) {
-                p.repeat();
+                p.repeat("the item completed");
             }
         });
         TaskStage.setAction(State.Terminated, (PlanItem<?> p, Transition t) -> {
             p.terminateInstance();
             if (p.getEntryCriteria().isEmpty()) {
-                p.repeat();
+                p.repeat("the item terminated");
             }
         });
         TaskStage.setAction(State.Failed, (PlanItem<?> p, Transition t) -> p.failInstance());


### PR DESCRIPTION
Fixes #286

Also safeguarded plan item index increments.
Also added some additional logging upon running the repeat logic.