### PR TITLE
Support multiple versions of same CalculationStep

### DIFF
--- a/src/main/java/org/cafienne/processtask/implementation/calculation/CalculationDefinition.java
+++ b/src/main/java/org/cafienne/processtask/implementation/calculation/CalculationDefinition.java
@@ -13,12 +13,14 @@ import org.cafienne.cmmn.instance.task.process.ProcessTask;
 import org.cafienne.processtask.definition.InlineSubProcessDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.FilterStepDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.MapStepDefinition;
+import org.cafienne.processtask.implementation.calculation.definition.MultiStepDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.StepDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.source.InputParameterSourceDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.source.SourceDefinition;
 import org.w3c.dom.Element;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CalculationDefinition extends InlineSubProcessDefinition {
     private final Collection<StepDefinition> steps = new ArrayList<>();
@@ -32,7 +34,17 @@ public class CalculationDefinition extends InlineSubProcessDefinition {
 
         // Now, build the mapping chain; sources can be input parameters and also the mappings themselves
         getProcessDefinition().getInputParameters().forEach((name, parameter) -> sources.put(name, new InputParameterSourceDefinition(parameter)));
-        steps.forEach(mapping -> sources.put(mapping.getIdentifier(), mapping));
+
+        // If multiple steps have the same name, they need to be combined into a MultiStep that will be evaluated in order (based on the condition)
+        Set<String> stepIdentifiers = steps.stream().map(StepDefinition::getIdentifier).collect(Collectors.toSet());
+        stepIdentifiers.forEach(identifier -> {
+            List<StepDefinition> list = steps.stream().filter(step -> step.getIdentifier().equals(identifier)).collect(Collectors.toList());
+            if (list.size() > 1) {
+                sources.put(identifier, new MultiStepDefinition(this, identifier, list));
+            } else if (list.size() == 1) {
+                sources.put(identifier, list.get(0));
+            }
+        });
 
         // Make sure we have all output parameters covered for
         getProcessDefinition().getOutputParameters().forEach((name, parameter) -> {

--- a/src/main/java/org/cafienne/processtask/implementation/calculation/definition/MultiStepDefinition.java
+++ b/src/main/java/org/cafienne/processtask/implementation/calculation/definition/MultiStepDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 - 2019 Cafienne B.V.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cafienne.processtask.implementation.calculation.definition;
+
+import org.cafienne.processtask.implementation.calculation.Calculation;
+import org.cafienne.processtask.implementation.calculation.CalculationDefinition;
+import org.cafienne.processtask.implementation.calculation.operation.CalculationStep;
+import org.cafienne.processtask.implementation.calculation.operation.MultiStep;
+
+import java.util.List;
+
+public class MultiStepDefinition extends StepDefinition {
+    private final List<StepDefinition> steps;
+    public MultiStepDefinition(CalculationDefinition calculationDefinition, String identifier, List<StepDefinition> list) {
+        super(calculationDefinition, identifier);
+        this.steps = list;
+    }
+
+    public List<StepDefinition> getSteps() {
+        return steps;
+    }
+
+    @Override
+    public CalculationStep createInstance(Calculation calculation) {
+        return new MultiStep(calculation, this);
+    }
+
+    public boolean hasDependency(StepDefinition stepDefinition) {
+        return this.steps.stream().anyMatch(step -> step.hasDependency(stepDefinition));
+    }
+
+    @Override
+    public String getType() {
+        return "Multi output step";
+    }
+
+    @Override
+    protected boolean equalsWith(Object object) {
+        return notYetImplemented();
+    }
+}

--- a/src/main/java/org/cafienne/processtask/implementation/calculation/definition/StepDefinition.java
+++ b/src/main/java/org/cafienne/processtask/implementation/calculation/definition/StepDefinition.java
@@ -11,13 +11,13 @@ import org.cafienne.cmmn.definition.CMMNElementDefinition;
 import org.cafienne.cmmn.definition.ModelDefinition;
 import org.cafienne.json.Value;
 import org.cafienne.processtask.implementation.calculation.Calculation;
+import org.cafienne.processtask.implementation.calculation.CalculationDefinition;
 import org.cafienne.processtask.implementation.calculation.Result;
 import org.cafienne.processtask.implementation.calculation.definition.expression.CalculationExpressionDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.expression.ConditionDefinition;
 import org.cafienne.processtask.implementation.calculation.definition.source.InputReference;
 import org.cafienne.processtask.implementation.calculation.definition.source.SourceDefinition;
 import org.cafienne.processtask.implementation.calculation.operation.CalculationStep;
-import org.cafienne.processtask.implementation.calculation.operation.Source;
 import org.cafienne.util.XMLHelper;
 import org.w3c.dom.Element;
 
@@ -48,6 +48,14 @@ public class StepDefinition extends CMMNElementDefinition implements SourceDefin
         this.condition = parse("condition", ConditionDefinition.class, false);
     }
 
+    protected StepDefinition(CalculationDefinition calculationDefinition, String identifier) {
+        super(calculationDefinition.getElement(), calculationDefinition.getModelDefinition(), calculationDefinition);
+        this.identifier = identifier;
+        this.expression = null;
+        this.condition = null;
+        this.inputs = new ArrayList<>();
+    }
+
     /**
      * Utility method for stream steps. Assures a single input only and returns that name
      *
@@ -66,7 +74,7 @@ public class StepDefinition extends CMMNElementDefinition implements SourceDefin
     }
 
     @Override
-    public Source<?> createInstance(Calculation calculation) {
+    public CalculationStep createInstance(Calculation calculation) {
         return new CalculationStep(calculation, this);
     }
 

--- a/src/main/java/org/cafienne/processtask/implementation/calculation/operation/MultiStep.java
+++ b/src/main/java/org/cafienne/processtask/implementation/calculation/operation/MultiStep.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 - 2019 Cafienne B.V.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cafienne.processtask.implementation.calculation.operation;
+
+import org.cafienne.processtask.implementation.calculation.Calculation;
+import org.cafienne.processtask.implementation.calculation.Result;
+import org.cafienne.processtask.implementation.calculation.definition.MultiStepDefinition;
+import org.cafienne.processtask.implementation.calculation.definition.StepDefinition;
+
+import java.util.List;
+
+public class MultiStep extends CalculationStep {
+    private final MultiStepDefinition definition;
+    private CalculationStep actualStep;
+
+    public MultiStep(Calculation calculation, MultiStepDefinition definition) {
+        super(calculation, definition);
+        this.definition = definition;
+    }
+
+    public boolean isValid() {
+        List<StepDefinition> options = definition.getSteps();
+        addDebugInfo(() -> "Checking isValid for " + definition.getIdentifier() +" on " + options.size() +" possible steps");
+        for (StepDefinition stepDefinition : options) {
+            actualStep = stepDefinition.createInstance(calculation);
+            if (actualStep.isValid()) {
+                addDebugInfo(() -> "actualStep["+definition.getIdentifier()+"]." + options.indexOf(stepDefinition) +".isValid() = " + true);
+                return true;
+            } else {
+                addDebugInfo(() -> "actualStep["+definition.getIdentifier()+"]." + options.indexOf(stepDefinition) +".isValid() = " + false);
+            }
+        }
+        addDebugInfo(() -> "Could not find a valid actual step, returning false on " + definition.getIdentifier());
+        return false;
+    }
+
+    protected Result calculateResult() {
+        return actualStep.calculateResult();
+    }
+}

--- a/src/main/java/org/cafienne/processtask/implementation/calculation/operation/Source.java
+++ b/src/main/java/org/cafienne/processtask/implementation/calculation/operation/Source.java
@@ -1,5 +1,6 @@
 package org.cafienne.processtask.implementation.calculation.operation;
 
+import org.cafienne.cmmn.instance.debug.DebugInfoAppender;
 import org.cafienne.processtask.implementation.calculation.Calculation;
 import org.cafienne.processtask.implementation.calculation.Result;
 import org.cafienne.processtask.implementation.calculation.definition.source.SourceDefinition;
@@ -12,6 +13,10 @@ public abstract class Source<D extends SourceDefinition> {
     protected Source(D definition, Calculation calculation) {
         this.definition = definition;
         this.calculation = calculation;
+    }
+
+    protected void addDebugInfo(DebugInfoAppender appender) {
+        calculation.getTask().getCaseInstance().addDebugInfo(appender);
     }
 
     public D getDefinition() {


### PR DESCRIPTION
In a CalculationDefinition it is now possible to add the same output multiple times, typically each with a condition.
The first step on which the condition is true will be executed.