### PR TITLE
Remove consume method from EventBatch trait

### DIFF
--- a/src/main/scala/org/cafienne/infrastructure/cqrs/TaggedEventSource.scala
+++ b/src/main/scala/org/cafienne/infrastructure/cqrs/TaggedEventSource.scala
@@ -30,6 +30,14 @@ trait TaggedEventSource extends ReadJournalProvider with LazyLogging  {
   val tag: String
 
   /**
+    * Query to retrieve the events as Source.
+    * Defaults to journal.eventsByTag, overrides can alternatively use journal.currentEventsByTag
+    * @param offset
+    * @return
+    */
+  def query(offset: Offset): Source[EventEnvelope, NotUsed] = journal().eventsByTag(tag, offset)
+
+  /**
     * Returns the Source
     */
   def taggedEvents: Source[ModelEventEnvelope, NotUsed] =
@@ -46,7 +54,7 @@ trait TaggedEventSource extends ReadJournalProvider with LazyLogging  {
         //  consuming that were consumed already successfully before the source had to be restarted.
         getOffset.map { offset: Offset =>
           logger.warn(s"Starting to read '$tag' events from offset " + offset)
-          journal().eventsByTag(tag, offset)
+          query(offset)
         }
       })
     }

--- a/src/main/scala/org/cafienne/infrastructure/cqrs/batch/EventBatch.scala
+++ b/src/main/scala/org/cafienne/infrastructure/cqrs/batch/EventBatch.scala
@@ -1,11 +1,9 @@
 package org.cafienne.infrastructure.cqrs.batch
 
-import akka.Done
 import org.cafienne.actormodel.event.CommitEvent
 import org.cafienne.infrastructure.cqrs.ModelEventEnvelope
 
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.Future
 
 trait EventBatch {
   val persistenceId: String
@@ -17,10 +15,4 @@ trait EventBatch {
   def addEvent(envelope: ModelEventEnvelope): Unit = {
     events += envelope
   }
-
-  /**
-    * Method that is invoked after a CommitEvent is added to the batch.
-    * @return
-    */
-  def consume(): Future[Done]
 }

--- a/src/main/scala/org/cafienne/querydb/materializer/QueryDBEventBatch.scala
+++ b/src/main/scala/org/cafienne/querydb/materializer/QueryDBEventBatch.scala
@@ -13,7 +13,7 @@ trait QueryDBEventBatch extends EventBatch {
 
   def commit(envelope: ModelEventEnvelope, transactionEvent: CommitEvent): Future[Done]
 
-  override def consume(): Future[Done] = {
+  def consume(): Future[Done] = {
     import scala.concurrent.ExecutionContext.Implicits.global
 
     // Create a chain of futures to be executed on the events

--- a/src/main/scala/org/cafienne/querydb/materializer/QueryDBEventSink.scala
+++ b/src/main/scala/org/cafienne/querydb/materializer/QueryDBEventSink.scala
@@ -7,9 +7,7 @@ import org.cafienne.system.health.HealthMonitor
 
 import scala.util.{Failure, Success}
 
-trait QueryDBEventSink extends EventBatchSource with LazyLogging {
-  override def createBatch(persistenceId: String): QueryDBEventBatch
-
+trait QueryDBEventSink extends EventBatchSource[QueryDBEventBatch] with LazyLogging {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   /**


### PR DESCRIPTION
The consume method is specific for QueryDBEventBatch, and does not belong inside the generic EventBatch trait.
Also:
EventBatchSource has become a generic, enabling implementations to receive a type specific batch as Source (instead of having to do .asInstanceOf calls).
Also generalized the query inside TaggedEventSource. Implementations can decide to override the default eventsByTag with currentEventsByTag.