### PR TITLE
Fix case file migration issue

### DIFF
--- a/src/main/java/org/cafienne/cmmn/actorapi/event/file/CaseFileItemChildRemoved.java
+++ b/src/main/java/org/cafienne/cmmn/actorapi/event/file/CaseFileItemChildRemoved.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 public class CaseFileItemChildRemoved extends CaseFileItemTransitioned {
     private final Path childPath;
 
-    public CaseFileItemChildRemoved(CaseFileItemCollection item, Path childPath) {
+    public CaseFileItemChildRemoved(CaseFileItemCollection<?> item, Path childPath) {
         super(item, State.Available, CaseFileItemTransition.RemoveChild, Value.NULL);
         this.childPath = childPath;
     }
@@ -50,9 +50,11 @@ public class CaseFileItemChildRemoved extends CaseFileItemTransitioned {
     @Override
     public void updateState(Case caseInstance) {
         try {
-            // Resolve the path on the case file
-            CaseFileItemCollection<?> caseFileItem = path.resolve(caseInstance);
-            caseFileItem.updateState(this);
+            // Resolve the path on the case file.
+            //  Note: we need to override this method instead of implementing the updateState(CaseFileItem item) method,
+            //  since we need to find the host that dropped this child, and host can be the CaseFile as well.
+            CaseFileItemCollection<?> host = path.resolve(caseInstance);
+            host.updateState(this);
         } catch (InvalidPathException shouldNotHappen) {
             logger.error("Could not recover path on case instance?!", shouldNotHappen);
         }

--- a/src/main/java/org/cafienne/cmmn/actorapi/event/file/CaseFileItemTransitioned.java
+++ b/src/main/java/org/cafienne/cmmn/actorapi/event/file/CaseFileItemTransitioned.java
@@ -35,8 +35,6 @@ public class CaseFileItemTransitioned extends CaseFileEvent implements StandardE
     private final Value<?> value;
     private final State state;
 
-    protected transient CaseFileItem caseFileItem;
-
     public CaseFileItemTransitioned(CaseFileItemCollection<?> item, State newState, CaseFileItemTransition transition, Value<?> newValue) {
         super(item);
         this.transition = transition;
@@ -91,17 +89,6 @@ public class CaseFileItemTransitioned extends CaseFileEvent implements StandardE
      */
     public Value<?> getValue() {
         return value;
-    }
-
-    @Override
-    public void updateState(Case caseInstance) {
-        try {
-            // Resolve the path on the case file
-            caseFileItem = path.resolve(caseInstance);
-            caseFileItem.publishTransition(this);
-        } catch (InvalidPathException shouldNotHappen) {
-            logger.error("Could not recover path on case instance?!", shouldNotHappen);
-        }
     }
 
     @Override

--- a/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFile.java
+++ b/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFile.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class CaseFile extends CaseFileItemCollection<CaseFileDefinition> {
     public CaseFile(Case caseInstance, CaseFileDefinition definition) {
-        super(caseInstance, definition);
+        super(caseInstance, definition, null);
     }
 
     /**

--- a/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItem.java
+++ b/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItem.java
@@ -56,7 +56,7 @@ public class CaseFileItem extends CaseFileItemCollection<CaseFileItemDefinition>
     private final boolean isArray;
 
     private CaseFileItem(Case caseInstance, CaseFileItemDefinition definition, CaseFileItemCollection<?> parent, CaseFileItemArray array, int indexInArray, boolean isArray) {
-        super(caseInstance, definition);
+        super(caseInstance, definition, parent);
         this.parent = parent instanceof CaseFileItem ? (CaseFileItem) parent : null;
         this.container = array == null ? this : array;
         this.indexInArray = indexInArray;
@@ -608,7 +608,7 @@ public class CaseFileItem extends CaseFileItemCollection<CaseFileItemDefinition>
     }
 
     public void updateState(CaseFileItemDropped event) {
-        parent.childDropped(this);
+        host.childDropped(this); // Inform our host (whether CaseFile or CaseFileItem) about us leaving the grid.
         businessIdentifiers.values().forEach(BusinessIdentifier::lostDefinition);
         getCaseInstance().getSentryNetwork().disconnect(this);
     }

--- a/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItemCollection.java
+++ b/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItemCollection.java
@@ -28,9 +28,11 @@ public abstract class CaseFileItemCollection<T extends CaseFileItemCollectionDef
      * Child items of this collection.
      */
     private final List<CaseFileItem> items = new ArrayList<>();
+    protected final CaseFileItemCollection<?> host; // Either the case file or the parent item of this collection
 
-    protected CaseFileItemCollection(Case caseInstance, T definition) {
+    protected CaseFileItemCollection(Case caseInstance, T definition, CaseFileItemCollection<?> host) {
         super(caseInstance, definition);
+        this.host = host;
     }
 
     private CaseFileItem constructItem(CaseFileItemDefinition childDefinition) {
@@ -89,6 +91,13 @@ public abstract class CaseFileItemCollection<T extends CaseFileItemCollectionDef
      * @return
      */
     public CaseFileItem getItem(String childName) {
+        // Let's first iterate our existing items for a child with this name.
+        //  Reason: when recovering the event on a dropped case file item
+        //  the new definition no longer has this child, leading to recovery errors.
+        //  The item still exists, but not it's definition. Therefore we first check the existing items.
+        for (CaseFileItem item : getItems()) {
+            if (item.getName().equals(childName)) return item;
+        }
         CaseFileItemDefinition childDefinition = getDefinition().getChild(childName);
         if (childDefinition == null) {
             return null;


### PR DESCRIPTION
Fixes #350

Note: also dropped duplicate code from CaseFileTransitioned (since it is also available in the base class CaseFileEvent). Note further that similar duplication from CaseFileItemChildRemoved can NOT be dropped.