### PR TITLE
Handle plan item with trailing spaces

### DIFF
--- a/src/main/java/org/cafienne/cmmn/actorapi/event/plan/CasePlanEvent.java
+++ b/src/main/java/org/cafienne/cmmn/actorapi/event/plan/CasePlanEvent.java
@@ -57,7 +57,7 @@ public abstract class CasePlanEvent extends CaseBaseEvent {
         this.planItemId = json.readString(Fields.planItemId);
         // Stage id is promoted from only PlanItemCreated into each CasePlanEvent. Older events do not have it, and get an empty value.
         this.stageId = json.readString(Fields.stageId, "");
-        this.path = json.readPath(Fields.path, "");
+        this.path = Path.untrimmed(json.readString(Fields.path, ""));
         this.type = json.readEnum(Fields.type, PlanItemType.class);
         this.planItem = null; // Not available in event reading, except inside recovery of an event.
         this.index = readIndex(path, json);

--- a/src/main/java/org/cafienne/cmmn/actorapi/event/plan/PlanItemCreated.java
+++ b/src/main/java/org/cafienne/cmmn/actorapi/event/plan/PlanItemCreated.java
@@ -35,13 +35,6 @@ import java.time.Instant;
 public class PlanItemCreated extends CasePlanEvent {
     public final String definitionId;
 
-    private static Path createPath(Path parent, ItemDefinition definition, int index) {
-        String parentPath = parent.isEmpty() ? "" : parent + "/";
-        boolean mayRepeat = !definition.getPlanItemControl().getRepetitionRule().isDefault();
-        String myPath = definition.getName() + (mayRepeat ? "[" + index + "]" : "");
-        return new Path(parentPath + myPath);
-    }
-
     public PlanItemCreated(Case caseInstance) {
         this(caseInstance, new Guid().toString(), "", new Path(""), caseInstance.getDefinition().getCasePlanModel(), 0);
     }
@@ -51,7 +44,7 @@ public class PlanItemCreated extends CasePlanEvent {
     }
 
     private PlanItemCreated(Case caseInstance, String planItemId, String parentStage, Path parentPath, ItemDefinition definition, int index) {
-        super(caseInstance, planItemId, parentStage, createPath(parentPath, definition, index), definition.getPlanItemDefinition().getItemType(), null);
+        super(caseInstance, planItemId, parentStage, new Path(parentPath, definition, index), definition.getPlanItemDefinition().getItemType(), null);
         this.definitionId = definition.getId();
     }
 

--- a/src/main/java/org/cafienne/cmmn/definition/PlanFragmentDefinition.java
+++ b/src/main/java/org/cafienne/cmmn/definition/PlanFragmentDefinition.java
@@ -56,11 +56,11 @@ public abstract class PlanFragmentDefinition extends PlanItemDefinitionDefinitio
     /**
      * Retrieve the definition of the plan item with the specified identifier, or null if no plan item with this id is available within this PlanFragment or Stage
      *
-     * @param planItemId
+     * @param identifier
      * @return
      */
-    public PlanItemDefinition getPlanItem(String planItemId) {
-        return planItems.stream().filter(p -> p.getId().equals(planItemId) || p.getName().equals(planItemId)).findFirst().orElse(null);
+    public PlanItemDefinition getPlanItem(String identifier) {
+        return planItems.stream().filter(p -> p.getId().equals(identifier) || p.getName().equals(identifier)).findFirst().orElse(null);
     }
 
     /**

--- a/src/main/java/org/cafienne/cmmn/instance/Path.java
+++ b/src/main/java/org/cafienne/cmmn/instance/Path.java
@@ -17,6 +17,7 @@
 
 package org.cafienne.cmmn.instance;
 
+import org.cafienne.cmmn.definition.ItemDefinition;
 import org.cafienne.cmmn.definition.casefile.CaseFileDefinition;
 import org.cafienne.cmmn.definition.casefile.CaseFileItemDefinition;
 import org.cafienne.cmmn.instance.casefile.*;
@@ -49,7 +50,17 @@ public class Path implements Serializable {
      * @throws InvalidPathException
      */
     public Path(String rawPath) throws InvalidPathException {
-        this(convertRawPath(rawPath), rawPath);
+        this(convertRawPath(rawPath, true), rawPath);
+    }
+
+    /**
+     * Returns a path object in which the individual names keep any trailing spaces.
+     * @param rawPath
+     * @return
+     * @throws InvalidPathException
+     */
+    public static Path untrimmed(String rawPath) throws InvalidPathException {
+        return new Path(convertRawPath(rawPath, false), rawPath);
     }
 
     /**
@@ -104,6 +115,16 @@ public class Path implements Serializable {
 
     public Path(PlanItem<?> planItem) {
         this(planItem, null);
+    }
+
+    public Path(Path parent, ItemDefinition definition, int index) {
+        this.parent = parent;
+        this.root = this.parent.root;
+        this.child = null;
+        this.depth = this.parent.depth + 1;
+        this.name = definition.getName();
+        this.index = index;
+        this.originalPath = toString();
     }
 
     private Path(PlanItem<?> planItem, Path child) {
@@ -453,7 +474,7 @@ public class Path implements Serializable {
      * @return
      * @throws InvalidPathException
      */
-    private static String[] convertRawPath(String rawPath) throws InvalidPathException {
+    private static String[] convertRawPath(String rawPath, boolean trim) throws InvalidPathException {
         if (rawPath == null) {
             throw new InvalidPathException("Missing path parameter");
         }
@@ -470,9 +491,11 @@ public class Path implements Serializable {
         }
 
         String[] pathElements = rawPath.split("/");
-        for (int i=0; i<pathElements.length; i++) {
-//            System.out.println("part["+i+"] = '" + pathElements[i] + "'");
-            pathElements[i] = pathElements[i].trim();
+        if (trim) {
+            for (int i=0; i<pathElements.length; i++) {
+//              System.out.println("part["+i+"] = '" + pathElements[i] + "'");
+                pathElements[i] = pathElements[i].trim();
+            }
         }
         return pathElements;
     }


### PR DESCRIPTION
Fixes #371

Path in plan items are no longer trimmed when serializing or deserializing