### PR TITLE
Fix optimization in CaseFileProjection

### DIFF
--- a/src/main/scala/org/cafienne/querydb/materializer/cases/file/CaseFileProjection.scala
+++ b/src/main/scala/org/cafienne/querydb/materializer/cases/file/CaseFileProjection.scala
@@ -107,12 +107,9 @@ class CaseFileProjection(batch: CaseEventBatch)(implicit val executionContext: E
 
   /**
     * Depending on the presence of CaseFileEvents this will add a new CaseFileRecord
-    *
-    * @param caseFileInProgress
-    * @return
     */
   private def getUpdatedCaseFile(caseFileInProgress: ValueMap): CaseFileRecord = {
-    bufferedCaseFileEvents.events.forEach(event => CaseFileMerger.merge(event, caseFileInProgress))
+    bufferedCaseFileEvents.update(caseFileInProgress)
     CaseFileRecord(caseInstanceId, tenant, caseFileInProgress.toString)
   }
 }


### PR DESCRIPTION
Fixes #428

Take correct path from CaseFileItemChildRemoved, and use that for updating the event list.

Also bit of refactoring to leave the merging of events to the CaseFileEventBuffer itself