### PR TITLE
Extend core UserIdentity to have additional roles

### DIFF
--- a/src/main/scala/org/cafienne/actormodel/identity/TenantUser.scala
+++ b/src/main/scala/org/cafienne/actormodel/identity/TenantUser.scala
@@ -25,7 +25,7 @@ import org.cafienne.tenant.actorapi.event.deprecated._
 
 import java.util
 
-final case class TenantUser(id: String, tenant: String, roles: Set[String] = Set(), isOwner: Boolean = false, name: String = "", email: String = "", enabled: Boolean = true) extends UserIdentity {
+final case class TenantUser(id: String, tenant: String, override val roles: Set[String] = Set(), isOwner: Boolean = false, name: String = "", email: String = "", enabled: Boolean = true) extends UserIdentity {
 
   import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/org/cafienne/actormodel/identity/UserIdentity.scala
+++ b/src/main/scala/org/cafienne/actormodel/identity/UserIdentity.scala
@@ -23,10 +23,20 @@ import org.cafienne.infrastructure.Cafienne
 import org.cafienne.infrastructure.serialization.{DeserializationError, Fields}
 import org.cafienne.json.{CafienneJson, Value, ValueMap}
 
+import scala.collection.immutable.HashSet
+
 trait UserIdentity extends CafienneJson {
   val id: String
 
-  override def toValue: Value[_] = new ValueMap(Fields.userId, id)
+  val roles: Set[String] = new HashSet()
+
+  override def toValue: Value[_] = {
+    val json = new ValueMap(Fields.userId, id)
+    if (roles.nonEmpty) {
+      json.put(Fields.roles, Value.convert(roles))
+    }
+    json
+  }
 
   def token: String = {
     val token = UserIdentity.tokens.get(id)

--- a/src/main/scala/org/cafienne/authentication/AuthenticatedUser.scala
+++ b/src/main/scala/org/cafienne/authentication/AuthenticatedUser.scala
@@ -19,14 +19,11 @@ package org.cafienne.authentication
 
 import com.nimbusds.jwt.JWTClaimsSet
 import org.cafienne.actormodel.identity.UserIdentity
-import org.cafienne.infrastructure.serialization.Fields
-import org.cafienne.json.{Value, ValueMap}
+import org.cafienne.json.ValueMap
 
 class AuthenticatedUser(override val token: String, claims: JWTClaimsSet) extends UserIdentity {
   val id: String = claims.getSubject
   UserIdentity.cacheUserToken(this)
-
-  override def toValue: Value[_] = new ValueMap(Fields.userId, id)
 }
 
 object AuthenticatedUser {


### PR DESCRIPTION
This helps in defining mechanisms to "bypass" TenantUser registration. Queries that read tenant roles on user level require such registration, but they are now also able to read the roles from the UserIdentity instead. In order to use this, one must extend the UserIdentity trait when executing queries or commands. This functionality is not exposed through the web api

fixes #448 