### PR TITLE
Stop timer tracking when they're triggered

### DIFF
--- a/engine/src/main/java/org/cafienne/storage/actormodel/BaseStorageActor.scala
+++ b/engine/src/main/java/org/cafienne/storage/actormodel/BaseStorageActor.scala
@@ -35,6 +35,8 @@ trait BaseStorageActor
   def reportUnknownMessage(msg: Any): Unit = {
     logger.warn(s"$metadata: Received message with unknown type. Ignoring it. Message is of type ${msg.getClass.getName}")
   }
+
+  override def toString: String = s"${this.getClass.getSimpleName}[$metadata]"
 }
 
 /**

--- a/engine/src/main/java/org/cafienne/storage/actormodel/StorageActor.scala
+++ b/engine/src/main/java/org/cafienne/storage/actormodel/StorageActor.scala
@@ -40,10 +40,11 @@ trait StorageActor[S <: StorageActorState]
   def createState(): S
 
   /**
-    * Invoked after the StorageActor has done it's job.
-    * This can be used to clean the storage job state.
-    * @param toSequenceNr Up to which event the journal must be cleared
-    */
+   * Invoked after the StorageActor has done it's job.
+   * This can be used to clean the storage job state.
+   *
+   * @param toSequenceNr Up to which event the journal must be cleared
+   */
   def clearState(toSequenceNr: Long = lastSequenceNr): Unit = {
     deleteMessages(toSequenceNr)
   }
@@ -70,10 +71,10 @@ trait StorageActor[S <: StorageActorState]
   }
 
   /**
-    * Triggers the storage process on the state directly if the state already
-    * has an initiation event, else if will simply add the given event
-    * which triggers the storage process in the state.
-    */
+   * Triggers the storage process on the state directly if the state already
+   * has an initiation event, else if will simply add the given event
+   * which triggers the storage process in the state.
+   */
   def startStorageProcess(): Unit = {
     if (state.hasStartEvent) {
       state.continueStorageProcess()

--- a/engine/src/main/java/org/cafienne/storage/deletion/state/DeletionState.scala
+++ b/engine/src/main/java/org/cafienne/storage/deletion/state/DeletionState.scala
@@ -86,7 +86,6 @@ trait DeletionState extends StorageActorState {
       }
       completing = true
       actor.completeStorageProcess()
-
     }
   }
 

--- a/engine/src/main/java/org/cafienne/timerservice/TimerJob.scala
+++ b/engine/src/main/java/org/cafienne/timerservice/TimerJob.scala
@@ -55,6 +55,7 @@ class TimerJob(val timerService: TimerService, val timer: Timer, val scheduler: 
   }
 
   def cancel(): Boolean = {
+    responseTracker.stop()
     schedule.cancel()
   }
 


### PR DESCRIPTION
When the TimerCleared event is received from the case, we should also stop the ResponseTracker, in order to avoid unnecessary invocations of RaiseEvent

Also small code improvements in the Storage area of the house