### PR TITLE
Also implicitly create array items for cfi onParts

### DIFF
--- a/engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItemArray.java
+++ b/engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItemArray.java
@@ -22,7 +22,6 @@ import org.cafienne.cmmn.definition.casefile.CaseFileError;
 import org.cafienne.cmmn.definition.casefile.CaseFileItemDefinition;
 import org.cafienne.cmmn.instance.Case;
 import org.cafienne.cmmn.instance.State;
-import org.cafienne.cmmn.instance.TransitionDeniedException;
 import org.cafienne.json.Value;
 import org.cafienne.json.ValueList;
 import org.slf4j.Logger;
@@ -239,10 +238,10 @@ public class CaseFileItemArray extends CaseFileItem implements List<CaseFileItem
         }
     }
 
-    @Override
-    public CaseFileItem getItem(String propertyName) {
-        // TODO: can we get rid of this override?
-        throw new TransitionDeniedException("Cannot access a property '" + propertyName + "' of the case file item container. Have to address an individual item");
+    protected CaseFileItem constructItem(CaseFileItemDefinition childDefinition) {
+        // Constructing an item for an array should do that on the current.
+        //  If current does not yet exist, we'll create a first array element.
+        return Objects.requireNonNullElseGet(this.current, this::getNextItem).constructItem(childDefinition);
     }
 
     @Override

--- a/engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItemCollection.java
+++ b/engine/src/main/java/org/cafienne/cmmn/instance/casefile/CaseFileItemCollection.java
@@ -45,7 +45,7 @@ public abstract class CaseFileItemCollection<T extends CaseFileItemCollectionDef
         this.host = host;
     }
 
-    private CaseFileItem constructItem(CaseFileItemDefinition childDefinition) {
+    protected CaseFileItem constructItem(CaseFileItemDefinition childDefinition) {
         CaseFileItem item = childDefinition.createInstance(getCaseInstance(), this);
         items.add(item);
         return item;


### PR DESCRIPTION
When an entry criterion (or any other criterion) has an onPart that listens to a case file item, it will try to connect to that item. The current onPart logic assumes that items will be created implicitly for such scenarios. This logic fails for array type of case file items and specifically their children. With this fix that is done anyway.

Fixes #478